### PR TITLE
Mac support and packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,20 +51,13 @@ Then run:
 uv sync
 source .venv/bin/activate
 
-# With GPU extras (for local evaluation)
+# With GPU extras (required for local evaluation)
 uv sync --extra gpu
-source .venv/bin/activate
-uv pip install --no-build-isolation flash-attn # Needed for faiss
-
-# With Qwen extras (for Qwen and Tongyi agents - requires GPU hardware)
-uv sync --extra qwen --extra gpu
 source .venv/bin/activate
 uv pip install --no-build-isolation flash-attn # Needed for faiss
 ```
 
-> **Note:** The base installation supports API-based agents (OpenAI, Anthropic, Gemini, GLM) and all retrieval functionality. Optional extras:
-> - `--extra gpu`: Adds vllm and deepspeed for local GPU-accelerated evaluation with `scripts_evaluation/evaluate_run.py`
-> - `--extra qwen`: Adds qwen-agent and qwen-omni-utils for Qwen-3 and Tongyi-DeepResearch agents (requires GPU hardware for vLLM server, typically used with `--extra gpu`)
+> **Note:** The base installation supports all search agents and retrieval functionality. The `--extra gpu` option adds vllm and deepspeed, which are needed for running local GPU-accelerated evaluation with `scripts_evaluation/evaluate_run.py`.
 
 Additionally, this repo depends on java 21. One way to install it is through conda:
 
@@ -209,7 +202,7 @@ where you can find the decrypted trajectory data in `data/decrypted_run_files/`.
 
 To reproduce results from BrowseComp-Plus, you can refer to the following docs for running the various search agents:
 
-### API-Based Agents (Base Installation)
+### API-Based Agents (Base Installation, No GPU Required)
 - [OpenAI API](docs/openai.md)
 - [Gemini API](docs/gemini.md)
 - [Anthropic API](docs/anthropic.md)
@@ -217,9 +210,9 @@ To reproduce results from BrowseComp-Plus, you can refer to the following docs f
 
 ### Self-Hosted Model Agents (Requires GPU)
 - [OSS](docs/oss.md) - Requires GPU for vLLM server
-- [Qwen-3](docs/qwen.md) - Requires `--extra qwen` and GPU for vLLM server
+- [Qwen-3](docs/qwen.md) - Requires GPU for model serving
 - [Search-R1](docs/search-r1.md) - Requires GPU for model serving
-- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md) - Requires `--extra qwen` and GPU for vLLM server
+- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md) - Requires GPU for model serving
 
 As an alternative to deploying the retrieval server yourself locally, you can also use a [pre-deployed MCP server from NetMind](docs/netmind_mcp.md).
 

--- a/README.md
+++ b/README.md
@@ -51,13 +51,20 @@ Then run:
 uv sync
 source .venv/bin/activate
 
-# With GPU extras (required for local evaluation)
+# With GPU extras (for local evaluation)
 uv sync --extra gpu
+source .venv/bin/activate
+uv pip install --no-build-isolation flash-attn # Needed for faiss
+
+# With Qwen extras (for Qwen and Tongyi agents - requires GPU hardware)
+uv sync --extra qwen --extra gpu
 source .venv/bin/activate
 uv pip install --no-build-isolation flash-attn # Needed for faiss
 ```
 
-> **Note:** The base installation supports all search agents and retrieval functionality. The `--extra gpu` option adds vllm and deepspeed, which are needed for running local GPU-accelerated evaluation with `scripts_evaluation/evaluate_run.py`.
+> **Note:** The base installation supports API-based agents (OpenAI, Anthropic, Gemini, GLM) and all retrieval functionality. Optional extras:
+> - `--extra gpu`: Adds vllm and deepspeed for local GPU-accelerated evaluation with `scripts_evaluation/evaluate_run.py`
+> - `--extra qwen`: Adds qwen-agent and qwen-omni-utils for Qwen-3 and Tongyi-DeepResearch agents (requires GPU hardware for vLLM server, typically used with `--extra gpu`)
 
 Additionally, this repo depends on java 21. One way to install it is through conda:
 
@@ -202,7 +209,7 @@ where you can find the decrypted trajectory data in `data/decrypted_run_files/`.
 
 To reproduce results from BrowseComp-Plus, you can refer to the following docs for running the various search agents:
 
-### API-Based Agents (Base Installation, No GPU Required)
+### API-Based Agents (Base Installation)
 - [OpenAI API](docs/openai.md)
 - [Gemini API](docs/gemini.md)
 - [Anthropic API](docs/anthropic.md)
@@ -210,9 +217,9 @@ To reproduce results from BrowseComp-Plus, you can refer to the following docs f
 
 ### Self-Hosted Model Agents (Requires GPU)
 - [OSS](docs/oss.md) - Requires GPU for vLLM server
-- [Qwen-3](docs/qwen.md) - Requires GPU for model serving
+- [Qwen-3](docs/qwen.md) - Requires `--extra qwen` and GPU for vLLM server
 - [Search-R1](docs/search-r1.md) - Requires GPU for model serving
-- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md) - Requires GPU for model serving
+- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md) - Requires `--extra qwen` and GPU for vLLM server
 
 As an alternative to deploying the retrieval server yourself locally, you can also use a [pre-deployed MCP server from NetMind](docs/netmind_mcp.md).
 

--- a/README.md
+++ b/README.md
@@ -47,10 +47,17 @@ you can find more information about its installation [here](https://docs.astral.
 Then run:
 
 ```bash
+# Base installation (works on all platforms)
 uv sync
+source .venv/bin/activate
+
+# With GPU extras (required for local evaluation)
+uv sync --extra gpu
 source .venv/bin/activate
 uv pip install --no-build-isolation flash-attn # Needed for faiss
 ```
+
+> **Note:** The base installation supports all search agents and retrieval functionality. The `--extra gpu` option adds vllm and deepspeed, which are needed for running local GPU-accelerated evaluation with `scripts_evaluation/evaluate_run.py`.
 
 Additionally, this repo depends on java 21. One way to install it is through conda:
 
@@ -114,7 +121,7 @@ python scripts_evaluation/evaluate_run.py --input_dir runs/my_model
 ```
 where you may pass in `--tensor_parallel_size {num_gpus}` to adjust the number of GPUs you have available.
 
-> Note that the script above evalutes using Qwen3-32B as a judge. For more details on evaluation, please refer to [docs/llm_as_judge.md](docs/llm_as_judge.md).
+> **Note:** The script above evaluates using Qwen3-32B as a judge and requires `uv sync --extra gpu` installation with GPU access. For alternative evaluation methods including legacy GPT-4.1 evaluation (no GPU required), please refer to [docs/llm_as_judge.md](docs/llm_as_judge.md).
 
 ### Submitting to the Leaderboard
 
@@ -194,14 +201,18 @@ where you can find the decrypted trajectory data in `data/decrypted_run_files/`.
 ## 📚 Docs
 
 To reproduce results from BrowseComp-Plus, you can refer to the following docs for running the various search agents:
+
+### API-Based Agents (Base Installation, No GPU Required)
 - [OpenAI API](docs/openai.md)
 - [Gemini API](docs/gemini.md)
 - [Anthropic API](docs/anthropic.md)
 - [GLM API](docs/glm.md)
-- [OSS](docs/oss.md)
-- [Qwen-3](docs/qwen.md)
-- [Search-R1](docs/search-r1.md)
-- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md)
+
+### Self-Hosted Model Agents (Requires GPU)
+- [OSS](docs/oss.md) - Requires GPU for vLLM server
+- [Qwen-3](docs/qwen.md) - Requires GPU for model serving
+- [Search-R1](docs/search-r1.md) - Requires GPU for model serving
+- [Tongyi-DeepResearch-30B-A3B](docs/tongyi.md) - Requires GPU for model serving
 
 As an alternative to deploying the retrieval server yourself locally, you can also use a [pre-deployed MCP server from NetMind](docs/netmind_mcp.md).
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ dependencies = [
     "pyngrok>=7.2.12",
     "pyserini>=1.2.0",
     "python-dotenv>=1.1.1",
-    "qwen-agent[gui,mcp,rag]==0.0.27",
-    "qwen-omni-utils==0.0.8",
     "rich>=14.0.0",
     "tevatron",
     "torchvision",
@@ -33,6 +31,10 @@ dependencies = [
 gpu = [
   "deepspeed>=0.17.2",
   "vllm>=0.9.0",
+]
+qwen = [
+  "qwen-agent[gui,mcp,rag]==0.0.27",
+  "qwen-omni-utils==0.0.8",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "tevatron",
     "torchvision",
     "tqdm>=4.67.1",
-    "transformers>=4.53.2",
+    "transformers>=4.53.2,<5.0",
     "tevatron @ git+https://github.com/texttron/tevatron.git@main",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "pyngrok>=7.2.12",
     "pyserini>=1.2.0",
     "python-dotenv>=1.1.1",
+    "qwen-agent[gui,mcp,rag]==0.0.27",
+    "qwen-omni-utils==0.0.8",
     "rich>=14.0.0",
     "tevatron",
     "torchvision",
@@ -31,10 +33,6 @@ dependencies = [
 gpu = [
   "deepspeed>=0.17.2",
   "vllm>=0.9.0",
-]
-qwen = [
-  "qwen-agent[gui,mcp,rag]==0.0.27",
-  "qwen-omni-utils==0.0.8",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools>=77.0.0"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "browsecomp-plus"
 version = "0.1.0"
@@ -33,3 +37,13 @@ gpu = [
 
 [tool.uv.sources]
 tevatron = { git = "https://github.com/texttron/tevatron.git", rev = "main" }
+
+[tool.setuptools]
+
+script-files = [
+  "scripts_build_index/download_indexes.sh",
+  "scripts_build_index/download_run_files.sh",
+]
+
+[tool.setuptools.packages.find]
+include = ["searcher*", "search_agent*", "scripts_evaluation*", "scripts_build_index*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ dependencies = [
     "accelerate>=1.9.0",
     "anthropic>=0.58.2",
     "datasets>=4.0.0",
-    "deepspeed>=0.17.2",
     "faiss-cpu>=1.11.0.post1",
     "fastmcp==2.9.2",
     "google-genai>=1.27.0",
@@ -23,7 +22,13 @@ dependencies = [
     "torchvision",
     "tqdm>=4.67.1",
     "transformers>=4.53.2",
-    "vllm>=0.9.0",
+    "tevatron @ git+https://github.com/texttron/tevatron.git@main",
+]
+
+[project.optional-dependencies]
+gpu = [
+  "deepspeed>=0.17.2",
+  "vllm>=0.9.0",
 ]
 
 [tool.uv.sources]

--- a/scripts_evaluation/evaluate_run.py
+++ b/scripts_evaluation/evaluate_run.py
@@ -11,31 +11,9 @@ from typing import Dict, List, Optional
 import numpy as np
 from tqdm import tqdm
 from vllm import LLM, SamplingParams
-
+from search_agent.prompts import GRADER_TEMPLATE_QWEN as GRADER_TEMPLATE
 sys.path.append(str(Path(__file__).parent.parent))
 
-GRADER_TEMPLATE = """
-Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
-
-[question]: {question}
-
-[response]: {response}
-
-[correct_answer]: {correct_answer}
-
-Your judgement must be in the format and criteria specified below:
-
-extracted_final_answer: The final exact answer extracted from the [response]. 
-
-[correct_answer]: Repeat the [correct_answer] given above.
-
-reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer], in the context of this [question]. You should judge whether the extracted_final_answer is semantically equivalent to [correct_answer], allowing the extracted_final_answer to be string variations of [correct_answer]. You should also allow the extracted_final_answer to be more precise or verbose than [correct_answer], as long as its additional details are correct. Do not comment on any background to the problem, do not attempt to solve the problem, do not argue for any answer different than [correct_answer], focus only on whether the answers are semantically equivalent.
-
-correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] given above, or is within a small margin of error for numerical problems. Answer 'no' otherwise, i.e. if there if there is any inconsistency, ambiguity, non-equivalency, or if the extracted answer is incorrect.
-
-
-confidence: The extracted confidence score between 0|\%| and 100|\%| from [response]. Put 100 if there is no confidence score available.
-""".strip()
 
 
 def load_ground_truth(jsonl_path: Path) -> Dict[str, Dict[str, str]]:

--- a/search_agent/prompts.py
+++ b/search_agent/prompts.py
@@ -64,6 +64,29 @@ correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] giv
 confidence: The extracted confidence score between 0|\%| and 100|\%| from [response]. Put 100 if there is no confidence score available.
 """.strip()
 
+GRADER_TEMPLATE_QWEN = """
+Judge whether the following [response] to [question] is correct or not based on the precise and unambiguous [correct_answer] below.
+
+[question]: {question}
+
+[response]: {response}
+
+[correct_answer]: {correct_answer}
+
+Your judgement must be in the format and criteria specified below:
+
+extracted_final_answer: The final exact answer extracted from the [response]. 
+
+[correct_answer]: Repeat the [correct_answer] given above.
+
+reasoning: Explain why the extracted_final_answer is correct or incorrect based on [correct_answer], in the context of this [question]. You should judge whether the extracted_final_answer is semantically equivalent to [correct_answer], allowing the extracted_final_answer to be string variations of [correct_answer]. You should also allow the extracted_final_answer to be more precise or verbose than [correct_answer], as long as its additional details are correct. Do not comment on any background to the problem, do not attempt to solve the problem, do not argue for any answer different than [correct_answer], focus only on whether the answers are semantically equivalent.
+
+correct: Answer 'yes' if extracted_final_answer matches the [correct_answer] given above, or is within a small margin of error for numerical problems. Answer 'no' otherwise, i.e. if there if there is any inconsistency, ambiguity, non-equivalency, or if the extracted answer is incorrect.
+
+
+confidence: The extracted confidence score between 0|\%| and 100|\%| from [response]. Put 100 if there is no confidence score available.
+""".strip()
+
 WEBSAILOR_SYSTEM_PROMPT_MULTI = """You are a Web Information Seeking Master. Your task is to thoroughly seek the internet for information and provide accurate answers to questions. No matter how complex the query, you will not give up until you find the corresponding information.
 
 As you proceed, adhere to the following principles:

--- a/search_agent/search_r1_client.py
+++ b/search_agent/search_r1_client.py
@@ -41,6 +41,25 @@ args = parser.parse_args()
 
 os.makedirs(args.output_dir, exist_ok=True)
 
+def detect_device():
+    if torch.cuda.is_available():
+        print(f"CUDA available: {torch.cuda.get_device_name(0)}")
+        return torch.device("cuda")
+    elif torch.backends.mps.is_available():
+        print("MPS available (Apple Silicon GPU)")
+        return torch.device("mps")
+    else:
+        print("Using CPU only (no GPU backend available)")
+        return torch.device("cpu")
+
+def get_model_dtype_and_device():
+    if torch.cuda.is_available():
+        return torch.bfloat16, "auto"
+    elif torch.backends.mps.is_available():
+        return torch.float16, None  # Don't use device_map with MPS
+    else:
+        return torch.float32, None
+
 if args.query.endswith(".tsv"):
     print(f"Loading questions from TSV file: {args.query}...")
     questions_to_process = pd.read_csv(
@@ -53,7 +72,7 @@ else:
     print("Processing 1 question")
 
 model_id = args.model
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+device = detect_device()
 curr_eos = [151645, 151643]  # for Qwen2.5 series models
 curr_search_template = (
     "\n\n{output_text}<information>{search_results}</information>\n\n"
@@ -61,8 +80,9 @@ curr_search_template = (
 
 print("Loading model and tokenizer...")
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
+dtype, device_map = get_model_dtype_and_device()
 model = transformers.AutoModelForCausalLM.from_pretrained(
-    model_id, torch_dtype=torch.bfloat16, device_map="auto"
+    model_id, torch_dtype=dtype, device_map=device_map
 )
 
 

--- a/search_agent/search_r1_client.py
+++ b/search_agent/search_r1_client.py
@@ -82,7 +82,7 @@ print("Loading model and tokenizer...")
 tokenizer = transformers.AutoTokenizer.from_pretrained(model_id)
 dtype, device_map = get_model_dtype_and_device()
 model = transformers.AutoModelForCausalLM.from_pretrained(
-    model_id, torch_dtype=dtype, device_map=device_map
+    model_id, dtype=dtype, device_map=device_map
 )
 
 

--- a/searcher/searchers/__init__.py
+++ b/searcher/searchers/__init__.py
@@ -5,25 +5,18 @@ Searchers package for different search implementations.
 from enum import Enum
 
 from .base import BaseSearcher
-from .bm25_searcher import BM25Searcher
-from .custom_searcher import CustomSearcher
-from .faiss_searcher import FaissSearcher, ReasonIrSearcher
 
 
 class SearcherType(Enum):
     """Enum for managing available searcher types and their CLI mappings."""
 
-    BM25 = ("bm25", BM25Searcher)
-    FAISS = ("faiss", FaissSearcher)
-    REASONIR = ("reasonir", ReasonIrSearcher)
-    CUSTOM = (
-        "custom",
-        CustomSearcher,
-    )  # Your custom searcher class, yet to be implemented
+    BM25 = "bm25"
+    FAISS = "faiss"
+    REASONIR = "reasonir"
+    CUSTOM = "custom"
 
-    def __init__(self, cli_name, searcher_class):
+    def __init__(self, cli_name):
         self.cli_name = cli_name
-        self.searcher_class = searcher_class
 
     @classmethod
     def get_choices(cls):
@@ -32,10 +25,19 @@ class SearcherType(Enum):
 
     @classmethod
     def get_searcher_class(cls, cli_name):
-        """Get searcher class by CLI name."""
-        for searcher_type in cls:
-            if searcher_type.cli_name == cli_name:
-                return searcher_type.searcher_class
+        """Get searcher class by CLI name, importing only when needed."""
+        if cli_name == cls.BM25.cli_name:
+            from .bm25_searcher import BM25Searcher
+            return BM25Searcher
+        elif cli_name == cls.FAISS.cli_name:
+            from .faiss_searcher import FaissSearcher
+            return FaissSearcher
+        elif cli_name == cls.REASONIR.cli_name:
+            from .faiss_searcher import ReasonIrSearcher
+            return ReasonIrSearcher
+        elif cli_name == cls.CUSTOM.cli_name:
+            from .custom_searcher import CustomSearcher
+            return CustomSearcher
         raise ValueError(f"Unknown searcher type: {cli_name}")
 
 

--- a/searcher/searchers/faiss_searcher.py
+++ b/searcher/searchers/faiss_searcher.py
@@ -178,7 +178,7 @@ class FaissSearcher(BaseSearcher):
             normalize=model_args.normalize,
             lora_name_or_path=model_args.lora_name_or_path,
             cache_dir=model_args.cache_dir,
-            torch_dtype=torch_dtype,
+            dtype=torch_dtype,
             attn_implementation=get_attn_implementation(self.device) #model_args.attn_implementation,
         )
 
@@ -336,7 +336,7 @@ class ReasonIrSearcher(FaissSearcher):
         self.model = AutoModel.from_pretrained(
             model_args.model_name_or_path,
             cache_dir=model_args.cache_dir,
-            torch_dtype=torch_dtype,
+            dtype=torch_dtype,
             trust_remote_code=True,
         )
         self.model = self.model.to(self.device)

--- a/searcher/searchers/faiss_searcher.py
+++ b/searcher/searchers/faiss_searcher.py
@@ -6,6 +6,7 @@ import glob
 import logging
 import os
 import pickle
+from contextlib import nullcontext
 from itertools import chain
 from typing import Any, Dict, List, Optional
 
@@ -83,6 +84,7 @@ class FaissSearcher(BaseSearcher):
         self.tokenizer = None
         self.lookup = None
         self.docid_to_text = None
+        self.device = detect_device()
 
         logger.info("Initializing FAISS searcher...")
 
@@ -177,10 +179,11 @@ class FaissSearcher(BaseSearcher):
             lora_name_or_path=model_args.lora_name_or_path,
             cache_dir=model_args.cache_dir,
             torch_dtype=torch_dtype,
-            attn_implementation=model_args.attn_implementation,
+            attn_implementation=get_attn_implementation(self.device) #model_args.attn_implementation,
         )
 
-        self.model = self.model.to("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = self.model.to(self.device)
+
         self.model.eval()
 
         self.tokenizer = AutoTokenizer.from_pretrained(
@@ -260,10 +263,10 @@ class FaissSearcher(BaseSearcher):
             return_tensors="pt",
         )
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-        batch_dict = {k: v.to(device) for k, v in batch_dict.items()}
+        batch_dict = {k: v.to(self.device) for k, v in batch_dict.items()}
 
-        with torch.amp.autocast(device):
+
+        with self.get_autocast_ctx():
             with torch.no_grad():
                 q_reps = self.model.encode_query(batch_dict)
                 q_reps = q_reps.cpu().detach().numpy()
@@ -298,6 +301,13 @@ class FaissSearcher(BaseSearcher):
     def search_type(self) -> str:
         return "FAISS"
 
+    def get_autocast_ctx(self):
+        if self.device.type in ["cpu", "cuda"]:
+            return torch.amp.autocast(device_type=self.device.type)
+        else:
+            # MPS: autocast not supported -> use nullcontext
+            return nullcontext()
+
 
 class ReasonIrSearcher(FaissSearcher):
     def _load_model(self) -> None:
@@ -329,7 +339,7 @@ class ReasonIrSearcher(FaissSearcher):
             torch_dtype=torch_dtype,
             trust_remote_code=True,
         )
-        self.model = self.model.to("cuda" if torch.cuda.is_available() else "cpu")
+        self.model = self.model.to(self.device)
         self.model.eval()
 
         logger.info("Model loaded successfully")
@@ -338,9 +348,7 @@ class ReasonIrSearcher(FaissSearcher):
         if not all([self.retriever, self.model, self.lookup]):
             raise RuntimeError("Searcher not properly initialized")
 
-        device = "cuda" if torch.cuda.is_available() else "cpu"
-
-        with torch.amp.autocast(device):
+        with self.get_autocast_ctx():
             with torch.no_grad():
                 q_reps = self.model.encode(
                     [query],
@@ -359,3 +367,33 @@ class ReasonIrSearcher(FaissSearcher):
             )
 
         return results
+
+def detect_device():
+    if torch.cuda.is_available():
+        device = torch.device("cuda")
+        print(f"CUDA available: {torch.cuda.get_device_name(0)}")
+    elif torch.backends.mps.is_available():
+        device = torch.device("mps")
+        print("MPS available (Apple Silicon GPU)")
+    else:
+        device = torch.device("cpu")
+        print("Using CPU only (no GPU backend available)")
+    return device
+
+
+def has_flash_attn():
+    try:
+        import flash_attn
+        return True
+    except ImportError:
+        return False
+
+def get_attn_implementation(device):
+    if device == torch.device("cuda") and has_flash_attn():
+        return "flash_attention_2"
+    elif device == torch.device("mps"):
+        return "sdpa"
+    elif device == torch.device("cpu"):
+        return "eager"
+    raise ValueError("Unknown device {}".format(device))
+

--- a/uv.lock
+++ b/uv.lock
@@ -440,8 +440,6 @@ dependencies = [
     { name = "pyngrok" },
     { name = "pyserini" },
     { name = "python-dotenv" },
-    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
-    { name = "qwen-omni-utils" },
     { name = "rich" },
     { name = "tevatron" },
     { name = "torchvision" },
@@ -453,6 +451,10 @@ dependencies = [
 gpu = [
     { name = "deepspeed" },
     { name = "vllm" },
+]
+qwen = [
+    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
+    { name = "qwen-omni-utils" },
 ]
 
 [package.metadata]
@@ -469,8 +471,8 @@ requires-dist = [
     { name = "pyngrok", specifier = ">=7.2.12" },
     { name = "pyserini", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
-    { name = "qwen-omni-utils", specifier = "==0.0.8" },
+    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], marker = "extra == 'qwen'", specifier = "==0.0.27" },
+    { name = "qwen-omni-utils", marker = "extra == 'qwen'", specifier = "==0.0.8" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
     { name = "torchvision" },
@@ -478,7 +480,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.53.2" },
     { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.9.0" },
 ]
-provides-extras = ["gpu"]
+provides-extras = ["gpu", "qwen"]
 
 [[package]]
 name = "cachetools"

--- a/uv.lock
+++ b/uv.lock
@@ -440,6 +440,8 @@ dependencies = [
     { name = "pyngrok" },
     { name = "pyserini" },
     { name = "python-dotenv" },
+    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
+    { name = "qwen-omni-utils" },
     { name = "rich" },
     { name = "tevatron" },
     { name = "torchvision" },
@@ -451,10 +453,6 @@ dependencies = [
 gpu = [
     { name = "deepspeed" },
     { name = "vllm" },
-]
-qwen = [
-    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
-    { name = "qwen-omni-utils" },
 ]
 
 [package.metadata]
@@ -471,8 +469,8 @@ requires-dist = [
     { name = "pyngrok", specifier = ">=7.2.12" },
     { name = "pyserini", specifier = ">=1.2.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], marker = "extra == 'qwen'", specifier = "==0.0.27" },
-    { name = "qwen-omni-utils", marker = "extra == 'qwen'", specifier = "==0.0.8" },
+    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
+    { name = "qwen-omni-utils", specifier = "==0.0.8" },
     { name = "rich", specifier = ">=14.0.0" },
     { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
     { name = "torchvision" },
@@ -480,7 +478,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=4.53.2,<5.0" },
     { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.9.0" },
 ]
-provides-extras = ["gpu", "qwen"]
+provides-extras = ["gpu"]
 
 [[package]]
 name = "cachetools"

--- a/uv.lock
+++ b/uv.lock
@@ -477,7 +477,7 @@ requires-dist = [
     { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
     { name = "torchvision" },
     { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "transformers", specifier = ">=4.53.2" },
+    { name = "transformers", specifier = ">=4.53.2,<5.0" },
     { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.9.0" },
 ]
 provides-extras = ["gpu", "qwen"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
@@ -423,6 +423,62 @@ sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e0485151
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
 ]
+
+[[package]]
+name = "browsecomp-plus"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "accelerate" },
+    { name = "anthropic" },
+    { name = "datasets" },
+    { name = "faiss-cpu" },
+    { name = "fastmcp" },
+    { name = "google-genai" },
+    { name = "openai" },
+    { name = "peft" },
+    { name = "pyngrok" },
+    { name = "pyserini" },
+    { name = "python-dotenv" },
+    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
+    { name = "qwen-omni-utils" },
+    { name = "rich" },
+    { name = "tevatron" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers" },
+]
+
+[package.optional-dependencies]
+gpu = [
+    { name = "deepspeed" },
+    { name = "vllm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "accelerate", specifier = ">=1.9.0" },
+    { name = "anthropic", specifier = ">=0.58.2" },
+    { name = "datasets", specifier = ">=4.0.0" },
+    { name = "deepspeed", marker = "extra == 'gpu'", specifier = ">=0.17.2" },
+    { name = "faiss-cpu", specifier = ">=1.11.0.post1" },
+    { name = "fastmcp", specifier = "==2.9.2" },
+    { name = "google-genai", specifier = ">=1.27.0" },
+    { name = "openai", specifier = ">=1.97.0" },
+    { name = "peft", specifier = ">=0.16.0" },
+    { name = "pyngrok", specifier = ">=7.2.12" },
+    { name = "pyserini", specifier = ">=1.2.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
+    { name = "qwen-omni-utils", specifier = "==0.0.8" },
+    { name = "rich", specifier = ">=14.0.0" },
+    { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
+    { name = "torchvision" },
+    { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "transformers", specifier = ">=4.53.2" },
+    { name = "vllm", marker = "extra == 'gpu'", specifier = ">=0.9.0" },
+]
+provides-extras = ["gpu"]
 
 [[package]]
 name = "cachetools"
@@ -901,7 +957,6 @@ dependencies = [
     { name = "numpy" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/f4/7c2136f4660ca504266cc08b38df2aa1db14fea93393b82e099ff34d7290/faiss_cpu-1.11.0.post1.tar.gz", hash = "sha256:06b1ea9ddec9e4d9a41c8ef7478d493b08d770e9a89475056e963081eed757d1", size = 70543, upload-time = "2025-07-15T09:15:02.127Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/29/b5c3fb0815449a5c7f1dd507da68ab30ab7a2a497178d5b4e365799f7670/faiss_cpu-1.11.0.post1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:e079d44ea22919f6477fea553b05854c68838ab553e1c6b1237437a8becdf89d", size = 7886451, upload-time = "2025-07-15T09:13:32.159Z" },
     { url = "https://files.pythonhosted.org/packages/b9/85/e526467ac75ef915b1444d5a1e9ef7af54d73242f923e664fffc2db65d54/faiss_cpu-1.11.0.post1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:4ded0c91cb67f462ae00a4d339718ea2fbb23eedbf260c3a07de77c32c23205a", size = 3308139, upload-time = "2025-07-15T09:13:34.033Z" },
@@ -1324,57 +1379,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/36/bbdede67400277bef33d3ec0e6a31750da972c469f75966b4930c753218f/groovy-0.1.2.tar.gz", hash = "sha256:25c1dc09b3f9d7e292458aa762c6beb96ea037071bf5e917fc81fb78d2231083", size = 17325, upload-time = "2025-02-28T20:24:56.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl", hash = "sha256:7f7975bab18c729a257a8b1ae9dcd70b7cafb1720481beae47719af57c35fa64", size = 14090, upload-time = "2025-02-28T20:24:55.152Z" },
-]
-
-[[package]]
-name = "browsecomp-plus"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "accelerate" },
-    { name = "anthropic" },
-    { name = "datasets" },
-    { name = "deepspeed" },
-    { name = "faiss-cpu" },
-    { name = "fastmcp" },
-    { name = "google-genai" },
-    { name = "openai" },
-    { name = "peft" },
-    { name = "pyngrok" },
-    { name = "pyserini" },
-    { name = "python-dotenv" },
-    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
-    { name = "qwen-omni-utils" },
-    { name = "rich" },
-    { name = "tevatron" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "vllm" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "accelerate", specifier = ">=1.9.0" },
-    { name = "anthropic", specifier = ">=0.58.2" },
-    { name = "datasets", specifier = ">=4.0.0" },
-    { name = "deepspeed", specifier = ">=0.17.2" },
-    { name = "faiss-cpu", specifier = ">=1.11.0.post1" },
-    { name = "fastmcp", specifier = "==2.9.2" },
-    { name = "google-genai", specifier = ">=1.27.0" },
-    { name = "openai", specifier = ">=1.97.0" },
-    { name = "peft", specifier = ">=0.16.0" },
-    { name = "pyngrok", specifier = ">=7.2.12" },
-    { name = "pyserini", specifier = ">=1.2.0" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
-    { name = "qwen-omni-utils", specifier = "==0.0.8" },
-    { name = "rich", specifier = ">=14.0.0" },
-    { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
-    { name = "torchvision" },
-    { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "transformers", specifier = ">=4.53.2" },
-    { name = "vllm", specifier = ">=0.9.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Several modifications for improved cross-platform support and external integration:
1. Mac compatibility: Allow running searchers on MPS and move Linux-dependent packages (deepspeed, vllm) to optional extras
2. Optional Java: Allow running non-BM25 searchers without Java installed (lazy import BM25 only when used)
3. Pip installable: Add setuptools configuration to allow installing the repo and importing its components externally