### PR TITLE
Setup and evaluation

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,167 @@
+# Running BrowseComp-Plus with Qwen3.5-9B on a Single RTX 4090
+
+This documents everything needed to run the BrowseComp-Plus benchmark using
+`Qwen/Qwen3.5-9B` as the search agent on a single RTX 4090 (24 GB VRAM).
+
+---
+
+## One-time fixes applied to this repo
+
+These changes were made once and are already committed to the working tree.
+
+### 1. Install Java 21 (required by pyserini/BM25)
+
+```bash
+apt update && apt install -y openjdk-21-jdk
+```
+
+### 2. Upgrade vllm to support Qwen3.5
+
+`Qwen/Qwen3.5-9B` uses the `Qwen3_5ForConditionalGeneration` architecture, which
+requires vllm ≥ 0.23.0. The original `pyproject.toml` pinned `vllm==0.9.0.1`.
+
+```bash
+source .venv/bin/activate
+uv pip install "vllm==0.23.0"
+```
+
+This also upgraded pydantic to 2.13.4, which broke `fastmcp==2.9.2`.
+
+### 3. Upgrade fastmcp to work with pydantic 2.13.x
+
+```bash
+uv pip install "fastmcp==2.14.7"
+```
+
+### 4. Patch pyserini's OpenAI import
+
+`pyserini` initialises an `openai.OpenAI()` client at import time with an empty
+string API key, which the newer openai SDK rejects. Fixed in:
+
+```
+.venv/lib/python3.10/site-packages/pyserini/encode/_openai.py  line ~27
+```
+
+Changed `api_key = ''` → `api_key = os.getenv("OPENAI_API_KEY") or "dummy"`.
+
+### 5. Make FAISS/tevatron imports lazy in the searcher package
+
+`vllm==0.23.0` pulled in `transformers==5.x`, which is incompatible with the
+pinned `peft` version. The `searchers/__init__.py` eagerly imported `FaissSearcher`
+(which depends on tevatron → peft), causing every `mcp_server.py` startup to fail
+even when only BM25 was requested.
+
+Fixed by making the FAISS and ReasonIR imports lazy (loaded on demand only when
+those searcher types are actually selected). See `searcher/searchers/__init__.py`.
+
+---
+
+## Running the benchmark
+
+Run the three commands below **in separate terminals** (or with `nohup … &` to
+background them). Start them in order and wait for each to be ready before
+starting the next.
+
+### Step 1 — Serve the LLM
+
+```bash
+source .venv/bin/activate
+
+vllm serve Qwen/Qwen3.5-9B \
+    --port 8000 \
+    --max-model-len 32768 \
+    --tensor-parallel-size 1 \
+    --gpu-memory-utilization 0.92 \
+    --quantization fp8 \
+    --trust-remote-code
+```
+
+Wait until the log prints `Application startup complete` (~4–5 min on first run
+due to torch.compile; faster on subsequent runs once the cache is warm).
+
+**Why FP8?** The model weights alone use ~21 GB in bf16, leaving no room for KV
+cache on a 24 GB card. FP8 halves the weight footprint to ~11 GB, freeing ~13 GB
+for the KV cache and allowing a 32 K context window.
+
+### Step 2 — Start the BM25 retrieval server
+
+```bash
+source .venv/bin/activate
+
+python searcher/mcp_server.py \
+    --searcher-type bm25 \
+    --index-path indexes/bm25 \
+    --port 8080 \
+    --transport sse
+```
+
+This uses the defaults: `--snippet-max-tokens 512` and `--k 5` (5 documents per
+search, each truncated to 512 tokens). Each search round adds ~2,560 tokens to
+the context.
+
+> **Context budget note:** with a 32 K window, 10 K output tokens, and a ~6,400
+> token initial prompt, there is room for roughly **6 search rounds** at default
+> settings before the context fills up. Queries that require more rounds will
+> fail with a 400 error and be skipped. If you need more rounds (the paper's
+> best models average 20+), reduce snippet size: add
+> `--snippet-max-tokens 256 --k 3` to fit ~21 rounds.
+
+### Step 3 — Run the agent over all 830 queries
+
+```bash
+source .venv/bin/activate
+
+python search_agent/qwen_client.py \
+    --model Qwen/Qwen3.5-9B \
+    --model-server http://localhost:8000/v1 \
+    --mcp-url "http://127.0.0.1:8080/mcp" \
+    --output-dir runs/bm25/qwen3.5-9b \
+    --query topics-qrels/queries.tsv \
+    --query-template QUERY_TEMPLATE_NO_GET_DOCUMENT
+```
+
+Results are saved incrementally to `runs/bm25/qwen3.5-9b/run_*.json`.
+If the run is interrupted, restarting the same command will skip already-processed
+query IDs automatically.
+
+**Expected rate:** ~50–70 s/query on a single RTX 4090 → ~14 hours for all 830.
+
+> **Note on `--max_tokens`:** The default is 10,000. Some queries that require
+> many search rounds will hit a 400 context-overflow error and be skipped; the
+> run continues and the checkpoint logic means they can be retried. This is
+> expected behaviour at default settings on a 32 K context window.
+
+---
+
+## Evaluation
+
+Once the run is complete, evaluate with a judge model. The paper uses **gpt-4.1**
+(OpenAI API); the script defaults to **Qwen/Qwen3-32B** as a local fallback.
+
+### Option A — gpt-4.1 (matches leaderboard scores)
+
+Requires an OpenAI API key and a small code change to `evaluate_run.py` to call
+the API instead of local vllm.
+
+### Option B — Qwen/Qwen3-8B (fits on the RTX 4090, free)
+
+First stop the vllm server from Step 1, then:
+
+```bash
+source .venv/bin/activate
+
+python scripts_evaluation/evaluate_run.py \
+    --input_dir runs/bm25/qwen3.5-9b \
+    --model Qwen/Qwen3-8B \
+    --tensor_parallel_size 1
+```
+
+Use the **same judge model** for both the baseline and the fine-tuned run so the
+relative improvement is comparable.
+
+---
+
+## Leaderboard submission
+
+After evaluation, edit the generated `evals/.../evaluation_summary.json` and fill
+in the `"LLM"`, `"Retriever"`, and `"Link"` fields before submitting.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,15 +1,24 @@
 # Running BrowseComp-Plus with Qwen3.5-9B on a Single RTX 4090
 
 This documents everything needed to run the BrowseComp-Plus benchmark using
-`Qwen/Qwen3.5-9B` as the search agent on a single RTX 4090 (24 GB VRAM).
+`Qwen/Qwen3.5-9B` as the search agent on a single RTX 4090 (24 GB VRAM),
+evaluate with a Together AI judge, and compare a baseline against a fine-tuned
+model.
+
+All commands assume you are in the repo root:
+```bash
+cd /workspace/BrowseComp-Plus
+source .venv/bin/activate
+```
 
 ---
 
 ## One-time fixes applied to this repo
 
-These changes were made once and are already committed to the working tree.
+These changes were made once and are already in the working tree — no need to
+repeat them.
 
-### 1. Install Java 21 (required by pyserini/BM25)
+### 1. Java 21 (required by pyserini / BM25)
 
 ```bash
 apt update && apt install -y openjdk-21-jdk
@@ -17,17 +26,16 @@ apt update && apt install -y openjdk-21-jdk
 
 ### 2. Upgrade vllm to support Qwen3.5
 
-`Qwen/Qwen3.5-9B` uses the `Qwen3_5ForConditionalGeneration` architecture, which
-requires vllm ≥ 0.23.0. The original `pyproject.toml` pinned `vllm==0.9.0.1`.
+`Qwen/Qwen3.5-9B` uses the `Qwen3_5ForConditionalGeneration` architecture,
+which requires vllm ≥ 0.23.0 (original pin was `vllm==0.9.0.1`).
 
 ```bash
-source .venv/bin/activate
 uv pip install "vllm==0.23.0"
 ```
 
-This also upgraded pydantic to 2.13.4, which broke `fastmcp==2.9.2`.
+This pulled in pydantic 2.13.4, which broke `fastmcp==2.9.2`.
 
-### 3. Upgrade fastmcp to work with pydantic 2.13.x
+### 3. Upgrade fastmcp
 
 ```bash
 uv pip install "fastmcp==2.14.7"
@@ -35,38 +43,33 @@ uv pip install "fastmcp==2.14.7"
 
 ### 4. Patch pyserini's OpenAI import
 
-`pyserini` initialises an `openai.OpenAI()` client at import time with an empty
-string API key, which the newer openai SDK rejects. Fixed in:
+`pyserini` initialises an `openai.OpenAI()` client at import time using an empty
+string API key, which the newer openai SDK rejects. Patched in:
 
 ```
-.venv/lib/python3.10/site-packages/pyserini/encode/_openai.py  line ~27
+.venv/lib/python3.10/site-packages/pyserini/encode/_openai.py  (~line 27)
 ```
 
-Changed `api_key = ''` → `api_key = os.getenv("OPENAI_API_KEY") or "dummy"`.
+`api_key = ''` → `api_key = os.getenv("OPENAI_API_KEY") or "dummy"`
 
-### 5. Make FAISS/tevatron imports lazy in the searcher package
+### 5. Lazy FAISS imports in the searcher package
 
-`vllm==0.23.0` pulled in `transformers==5.x`, which is incompatible with the
-pinned `peft` version. The `searchers/__init__.py` eagerly imported `FaissSearcher`
-(which depends on tevatron → peft), causing every `mcp_server.py` startup to fail
-even when only BM25 was requested.
-
-Fixed by making the FAISS and ReasonIR imports lazy (loaded on demand only when
-those searcher types are actually selected). See `searcher/searchers/__init__.py`.
+vllm 0.23.0 pulled in `transformers==5.x`, incompatible with the pinned `peft`.
+`searcher/searchers/__init__.py` eagerly imported `FaissSearcher` (which chains
+to tevatron → peft), crashing every `mcp_server.py` startup even when only BM25
+was needed. Fixed by making FAISS and ReasonIR imports lazy. See
+`searcher/searchers/__init__.py`.
 
 ---
 
-## Running the benchmark
+## Benchmark run
 
-Run the three commands below **in separate terminals** (or with `nohup … &` to
-background them). Start them in order and wait for each to be ready before
-starting the next.
+Start the three processes **in order**, each in its own terminal (or backgrounded
+with `nohup … &`). Wait for each to be ready before starting the next.
 
 ### Step 1 — Serve the LLM
 
 ```bash
-source .venv/bin/activate
-
 vllm serve Qwen/Qwen3.5-9B \
     --port 8000 \
     --max-model-len 32768 \
@@ -76,18 +79,16 @@ vllm serve Qwen/Qwen3.5-9B \
     --trust-remote-code
 ```
 
-Wait until the log prints `Application startup complete` (~4–5 min on first run
-due to torch.compile; faster on subsequent runs once the cache is warm).
+Ready when the log prints `Application startup complete` (~4–5 min on first run
+due to torch.compile; faster once the compile cache is warm).
 
-**Why FP8?** The model weights alone use ~21 GB in bf16, leaving no room for KV
+**Why FP8?** In bf16 the model weights alone use ~21 GB, leaving no room for KV
 cache on a 24 GB card. FP8 halves the weight footprint to ~11 GB, freeing ~13 GB
-for the KV cache and allowing a 32 K context window.
+for the KV cache and enabling the 32 K context window.
 
 ### Step 2 — Start the BM25 retrieval server
 
 ```bash
-source .venv/bin/activate
-
 python searcher/mcp_server.py \
     --searcher-type bm25 \
     --index-path indexes/bm25 \
@@ -95,22 +96,17 @@ python searcher/mcp_server.py \
     --transport sse
 ```
 
-This uses the defaults: `--snippet-max-tokens 512` and `--k 5` (5 documents per
-search, each truncated to 512 tokens). Each search round adds ~2,560 tokens to
-the context.
+Uses defaults: `--snippet-max-tokens 512`, `--k 5` (5 documents per search,
+each up to 512 tokens). Each search round adds ~2,560 tokens to the context.
 
-> **Context budget note:** with a 32 K window, 10 K output tokens, and a ~6,400
+> **Context budget:** with a 32 K window, ~10 K output tokens, and a ~6,400
 > token initial prompt, there is room for roughly **6 search rounds** at default
-> settings before the context fills up. Queries that require more rounds will
-> fail with a 400 error and be skipped. If you need more rounds (the paper's
-> best models average 20+), reduce snippet size: add
-> `--snippet-max-tokens 256 --k 3` to fit ~21 rounds.
+> settings. Queries that exceed this fail with a 400 error, are skipped, and can
+> be retried. To allow ~21 rounds instead, add `--snippet-max-tokens 256 --k 3`.
 
 ### Step 3 — Run the agent over all 830 queries
 
 ```bash
-source .venv/bin/activate
-
 python search_agent/qwen_client.py \
     --model Qwen/Qwen3.5-9B \
     --model-server http://localhost:8000/v1 \
@@ -120,48 +116,75 @@ python search_agent/qwen_client.py \
     --query-template QUERY_TEMPLATE_NO_GET_DOCUMENT
 ```
 
-Results are saved incrementally to `runs/bm25/qwen3.5-9b/run_*.json`.
-If the run is interrupted, restarting the same command will skip already-processed
-query IDs automatically.
+Results are written incrementally to `runs/bm25/qwen3.5-9b/run_*.json`.
+Restarting the same command automatically skips already-saved query IDs.
 
-**Expected rate:** ~50–70 s/query on a single RTX 4090 → ~14 hours for all 830.
-
-> **Note on `--max_tokens`:** The default is 10,000. Some queries that require
-> many search rounds will hit a 400 context-overflow error and be skipped; the
-> run continues and the checkpoint logic means they can be retried. This is
-> expected behaviour at default settings on a 32 K context window.
+**Expected rate:** ~50–70 s/query → ~14 hours for all 830 on a single RTX 4090.
 
 ---
 
 ## Evaluation
 
-Once the run is complete, evaluate with a judge model. The paper uses **gpt-4.1**
-(OpenAI API); the script defaults to **Qwen/Qwen3-32B** as a local fallback.
+`evaluate_run.py` supports two judge backends.
 
-### Option A — gpt-4.1 (matches leaderboard scores)
+### Option A — Together AI (recommended)
 
-Requires an OpenAI API key and a small code change to `evaluate_run.py` to call
-the API instead of local vllm.
-
-### Option B — Qwen/Qwen3-8B (fits on the RTX 4090, free)
-
-First stop the vllm server from Step 1, then:
+No local GPU needed. All 830 judgements run in parallel via the API.
 
 ```bash
-source .venv/bin/activate
+export TOGETHER_API_KEY="your_key_here"
 
+python scripts_evaluation/evaluate_run.py \
+    --input_dir runs/bm25/qwen3.5-9b \
+    --model google/gemma-4-31B-it \
+    --num-workers 8
+```
+
+`TOGETHER_API_KEY` is read from the environment automatically — no need to pass
+`--together-api-key` explicitly if the env var is set.  
+`--num-workers` controls parallel API threads (default 8).
+
+### Option B — Local vLLM (Qwen/Qwen3-8B, fits on the RTX 4090)
+
+Stop the vllm server from Step 1 first (to free the GPU), then:
+
+```bash
 python scripts_evaluation/evaluate_run.py \
     --input_dir runs/bm25/qwen3.5-9b \
     --model Qwen/Qwen3-8B \
     --tensor_parallel_size 1
 ```
 
-Use the **same judge model** for both the baseline and the fine-tuned run so the
-relative improvement is comparable.
+> Use the **same judge model** for both the baseline and the fine-tuned run so
+> the relative improvement is a fair comparison.
+
+---
+
+## Full workflow: baseline → fine-tune → compare
+
+```
+1. Run benchmark (Step 1–3 above)          → runs/bm25/qwen3.5-9b/
+2. Evaluate baseline                        → evals/bm25/qwen3.5-9b/evaluation_summary.json
+3. Fine-tune Qwen3.5-9B on your dataset
+4. Re-run benchmark with fine-tuned model   → runs/bm25/qwen3.5-9b-finetuned/
+5. Evaluate fine-tuned model (same judge)   → evals/bm25/qwen3.5-9b-finetuned/evaluation_summary.json
+6. Compare Accuracy (%) between the two summaries
+```
+
+For Step 4, swap `--model` and `--output-dir` in the qwen_client.py command to
+point at the fine-tuned checkpoint and a new output directory.
 
 ---
 
 ## Leaderboard submission
 
-After evaluation, edit the generated `evals/.../evaluation_summary.json` and fill
-in the `"LLM"`, `"Retriever"`, and `"Link"` fields before submitting.
+After evaluation, fill in the placeholder fields in
+`evals/.../evaluation_summary.json` before submitting:
+
+```json
+{
+  "LLM": "Qwen/Qwen3.5-9B",
+  "Retriever": "BM25",
+  "Link": "https://huggingface.co/..."
+}
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "qwen-omni-utils==0.0.8",
     "rich>=14.0.0",
     "tevatron",
+    "together>=2.19.0",
     "torchvision",
     "tqdm>=4.67.1",
     "transformers>=4.53.2",

--- a/scripts_evaluation/evaluate_run.py
+++ b/scripts_evaluation/evaluate_run.py
@@ -1,6 +1,8 @@
 import argparse
+import concurrent.futures
 import csv
 import json
+import os
 import re
 import sys
 from collections import defaultdict
@@ -10,7 +12,6 @@ from typing import Dict, List, Optional
 
 import numpy as np
 from tqdm import tqdm
-from vllm import LLM, SamplingParams
 
 sys.path.append(str(Path(__file__).parent.parent))
 
@@ -375,6 +376,46 @@ def save_detailed_csv(all_results: List[dict], output_dir: Path):
     return csv_path
 
 
+def run_together_inference(
+    prompts: List[str],
+    model: str,
+    api_key: str,
+    max_tokens: int,
+    temperature: float,
+    top_p: float,
+    num_workers: int = 8,
+) -> List[str]:
+    from together import Together
+
+    client = Together(api_key=api_key)
+
+    def _call(prompt: str) -> str:
+        try:
+            resp = client.chat.completions.create(
+                model=model,
+                messages=[{"role": "user", "content": prompt}],
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+            )
+            return resp.choices[0].message.content or ""
+        except Exception as e:
+            print(f"[Together error] {e}")
+            return ""
+
+    results = [None] * len(prompts)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+        future_to_idx = {executor.submit(_call, p): i for i, p in enumerate(prompts)}
+        for future in tqdm(
+            concurrent.futures.as_completed(future_to_idx),
+            total=len(prompts),
+            desc="Together API calls",
+            unit="req",
+        ):
+            results[future_to_idx[future]] = future.result()
+    return results
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Evaluate browsecomp responses using Qwen judge model."
@@ -425,7 +466,22 @@ def main():
         default=1,
         help="Tensor parallel size for vLLM",
     )
+    parser.add_argument(
+        "--together-api-key",
+        type=str,
+        default=None,
+        help="Together AI API key. If provided (or TOGETHER_API_KEY env var is set), "
+             "uses Together AI instead of local vLLM.",
+    )
+    parser.add_argument(
+        "--num-workers",
+        type=int,
+        default=8,
+        help="Parallel workers for Together AI API calls (default: 8)",
+    )
     args = parser.parse_args()
+
+    args.together_api_key = args.together_api_key or os.getenv("TOGETHER_API_KEY")
 
     input_dir = Path(args.input_dir)
     eval_dir = Path(args.eval_dir)
@@ -456,14 +512,21 @@ def main():
 
     all_results = []
 
-    # Initialize vLLM engine and sampling params
-    llm = LLM(model=args.model, tensor_parallel_size=args.tensor_parallel_size)
-    sampling_params = SamplingParams(
-        temperature=args.temperature,
-        top_p=args.top_p,
-        top_k=args.top_k,
-        max_tokens=args.max_output_tokens,
-    )
+    # Initialize inference backend
+    if args.together_api_key:
+        print(f"Using Together AI judge: {args.model}")
+        llm = None
+        sampling_params = None
+    else:
+        from vllm import LLM, SamplingParams
+        print(f"Using local vLLM judge: {args.model}")
+        llm = LLM(model=args.model, tensor_parallel_size=args.tensor_parallel_size)
+        sampling_params = SamplingParams(
+            temperature=args.temperature,
+            top_p=args.top_p,
+            top_k=args.top_k,
+            max_tokens=args.max_output_tokens,
+        )
 
     detected_model_name: Optional[str] = None
     first_run_path: Optional[Path] = json_files[0] if json_files else None
@@ -568,31 +631,52 @@ def main():
             }
         )
 
-    for i in tqdm(
-        range(0, len(pending_items), args.batch_size), desc="Evaluating", unit="batch"
-    ):
-        batch = pending_items[i : i + args.batch_size]
-        messages_list = [
-            [{"role": "user", "content": item["judge_prompt"]}] for item in batch
-        ]
-        try:
-            outputs = llm.chat(
-                messages_list,
-                sampling_params,
-                chat_template_kwargs={"enable_thinking": False},
-            )
-        except Exception as e:
-            print(f"Error running vLLM batch {i}//{args.batch_size}: {e}")
-            continue
+    if args.together_api_key:
+        # Together AI: run all prompts in parallel, then process results
+        all_prompts = [item["judge_prompt"] for item in pending_items]
+        all_judge_texts = run_together_inference(
+            prompts=all_prompts,
+            model=args.model,
+            api_key=args.together_api_key,
+            max_tokens=args.max_output_tokens,
+            temperature=args.temperature,
+            top_p=args.top_p,
+            num_workers=args.num_workers,
+        )
+        pending_with_texts = list(zip(pending_items, all_judge_texts))
+    else:
+        pending_with_texts = None  # handled in vllm loop below
 
-        for item, out in zip(batch, outputs or []):
-            judge_text = ""
+    if args.together_api_key:
+        items_and_texts = pending_with_texts
+    else:
+        items_and_texts = []
+        for i in tqdm(
+            range(0, len(pending_items), args.batch_size), desc="Evaluating", unit="batch"
+        ):
+            batch = pending_items[i : i + args.batch_size]
+            messages_list = [
+                [{"role": "user", "content": item["judge_prompt"]}] for item in batch
+            ]
             try:
-                if getattr(out, "outputs", None):
-                    judge_text = out.outputs[0].text or ""
-            except Exception:
+                outputs = llm.chat(
+                    messages_list,
+                    sampling_params,
+                    chat_template_kwargs={"enable_thinking": False},
+                )
+            except Exception as e:
+                print(f"Error running vLLM batch {i}//{args.batch_size}: {e}")
+                continue
+            for item, out in zip(batch, outputs or []):
                 judge_text = ""
+                try:
+                    if getattr(out, "outputs", None):
+                        judge_text = out.outputs[0].text or ""
+                except Exception:
+                    judge_text = ""
+                items_and_texts.append((item, judge_text))
 
+    for item, judge_text in items_and_texts:
             judge_result = parse_judge_response(judge_text)
             cited_docids = extract_citations_from_response(item["response"])
             citation_metrics_positives = compute_citation_metrics(

--- a/searcher/searchers/__init__.py
+++ b/searcher/searchers/__init__.py
@@ -7,15 +7,24 @@ from enum import Enum
 from .base import BaseSearcher
 from .bm25_searcher import BM25Searcher
 from .custom_searcher import CustomSearcher
-from .faiss_searcher import FaissSearcher, ReasonIrSearcher
+
+
+def _get_faiss_searcher():
+    from .faiss_searcher import FaissSearcher
+    return FaissSearcher
+
+
+def _get_reasonir_searcher():
+    from .faiss_searcher import ReasonIrSearcher
+    return ReasonIrSearcher
 
 
 class SearcherType(Enum):
     """Enum for managing available searcher types and their CLI mappings."""
 
     BM25 = ("bm25", BM25Searcher)
-    FAISS = ("faiss", FaissSearcher)
-    REASONIR = ("reasonir", ReasonIrSearcher)
+    FAISS = ("faiss", _get_faiss_searcher)
+    REASONIR = ("reasonir", _get_reasonir_searcher)
     CUSTOM = (
         "custom",
         CustomSearcher,
@@ -35,7 +44,11 @@ class SearcherType(Enum):
         """Get searcher class by CLI name."""
         for searcher_type in cls:
             if searcher_type.cli_name == cli_name:
-                return searcher_type.searcher_class
+                cls_or_loader = searcher_type.searcher_class
+                # Call lazy loader functions on demand
+                if callable(cls_or_loader) and not isinstance(cls_or_loader, type):
+                    return cls_or_loader()
+                return cls_or_loader
         raise ValueError(f"Unknown searcher type: {cli_name}")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'darwin'",
@@ -425,6 +425,59 @@ wheels = [
 ]
 
 [[package]]
+name = "browsecomp-plus"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "accelerate" },
+    { name = "anthropic" },
+    { name = "datasets" },
+    { name = "deepspeed" },
+    { name = "faiss-cpu" },
+    { name = "fastmcp" },
+    { name = "google-genai" },
+    { name = "openai" },
+    { name = "peft" },
+    { name = "pyngrok" },
+    { name = "pyserini" },
+    { name = "python-dotenv" },
+    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
+    { name = "qwen-omni-utils" },
+    { name = "rich" },
+    { name = "tevatron" },
+    { name = "together" },
+    { name = "torchvision" },
+    { name = "tqdm" },
+    { name = "transformers" },
+    { name = "vllm" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "accelerate", specifier = ">=1.9.0" },
+    { name = "anthropic", specifier = ">=0.58.2" },
+    { name = "datasets", specifier = ">=4.0.0" },
+    { name = "deepspeed", specifier = ">=0.17.2" },
+    { name = "faiss-cpu", specifier = ">=1.11.0.post1" },
+    { name = "fastmcp", specifier = "==2.9.2" },
+    { name = "google-genai", specifier = ">=1.27.0" },
+    { name = "openai", specifier = ">=1.97.0" },
+    { name = "peft", specifier = ">=0.16.0" },
+    { name = "pyngrok", specifier = ">=7.2.12" },
+    { name = "pyserini", specifier = ">=1.2.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1" },
+    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
+    { name = "qwen-omni-utils", specifier = "==0.0.8" },
+    { name = "rich", specifier = ">=14.0.0" },
+    { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
+    { name = "together", specifier = ">=2.19.0" },
+    { name = "torchvision" },
+    { name = "tqdm", specifier = ">=4.67.1" },
+    { name = "transformers", specifier = ">=4.53.2" },
+    { name = "vllm", specifier = ">=0.9.0" },
+]
+
+[[package]]
 name = "cachetools"
 version = "5.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -687,6 +740,23 @@ wheels = [
 ]
 
 [[package]]
+name = "cyclopts"
+version = "4.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "docstring-parser" },
+    { name = "rich" },
+    { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/e7/4b3048094559b86a800e0f0de7faf8e6d8213727cf31553ec58453f25abc/cyclopts-4.19.0.tar.gz", hash = "sha256:c7532803ab8560d4de8600769793c3de4b2dc8c3b23ec707b989d84d9bae6ff4", size = 189274, upload-time = "2026-06-22T23:58:54.176Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/e8/b84c32f35a19107b55b8ceed260de9469206464da26bd0b979db470782c3/cyclopts-4.19.0-py3-none-any.whl", hash = "sha256:a8c11adb45afae25db310122950c7639c70b56e2ce341e5b29848bf3a8ecc1d4", size = 228005, upload-time = "2026-06-22T23:58:52.495Z" },
+]
+
+[[package]]
 name = "cython"
 version = "3.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -815,6 +885,15 @@ wheels = [
 ]
 
 [[package]]
+name = "detect-agent"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/40/90675e9934cac99acb4d5df050dbed9418587775ed916f12844c71e6a53f/detect_agent-0.3.0.tar.gz", hash = "sha256:186e8a80638985574417ba752e74ca1b80341280dc6d4308b0a25b4e7bac50f3", size = 41995, upload-time = "2026-05-29T19:24:18.143Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/67/746fe6402fbe769431d09965f7808c586dcbb0764b4694d62785a88d8736/detect_agent-0.3.0-py3-none-any.whl", hash = "sha256:14c0ab0b90fca111eafea51d22f24fb187591e2a16eda8cbbe856a204ffdd7aa", size = 7815, upload-time = "2026-05-29T19:24:18.9Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.3.8"
 source = { registry = "https://pypi.org/simple" }
@@ -848,6 +927,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/4a/263763cb2ba3816dd94b08ad3a33d5fdae34ecb856678773cc40a3605829/dnspython-2.7.0.tar.gz", hash = "sha256:ce9c432eda0dc91cf618a5cedf1a4e142651196bbcd2c80e89ed5a907e5cfaf1", size = 345197, upload-time = "2024-10-05T20:14:59.362Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/1b/e0a87d256e40e8c888847551b20a017a6b98139178505dc7ffb96f04e954/dnspython-2.7.0-py3-none-any.whl", hash = "sha256:b4c34b7d10b51bcc3a5071e7b8dee77939f1e878477eeecc965e9835f63c6c86", size = 313632, upload-time = "2024-10-05T20:14:57.687Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
 ]
 
 [[package]]
@@ -901,7 +989,6 @@ dependencies = [
     { name = "numpy" },
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/f4/7c2136f4660ca504266cc08b38df2aa1db14fea93393b82e099ff34d7290/faiss_cpu-1.11.0.post1.tar.gz", hash = "sha256:06b1ea9ddec9e4d9a41c8ef7478d493b08d770e9a89475056e963081eed757d1", size = 70543, upload-time = "2025-07-15T09:15:02.127Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/29/b5c3fb0815449a5c7f1dd507da68ab30ab7a2a497178d5b4e365799f7670/faiss_cpu-1.11.0.post1-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:e079d44ea22919f6477fea553b05854c68838ab553e1c6b1237437a8becdf89d", size = 7886451, upload-time = "2025-07-15T09:13:32.159Z" },
     { url = "https://files.pythonhosted.org/packages/b9/85/e526467ac75ef915b1444d5a1e9ef7af54d73242f923e664fffc2db65d54/faiss_cpu-1.11.0.post1-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:4ded0c91cb67f462ae00a4d339718ea2fbb23eedbf260c3a07de77c32c23205a", size = 3308139, upload-time = "2025-07-15T09:13:34.033Z" },
@@ -1324,57 +1411,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/52/36/bbdede67400277bef33d3ec0e6a31750da972c469f75966b4930c753218f/groovy-0.1.2.tar.gz", hash = "sha256:25c1dc09b3f9d7e292458aa762c6beb96ea037071bf5e917fc81fb78d2231083", size = 17325, upload-time = "2025-02-28T20:24:56.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/28/27/3d6dcadc8a3214d8522c1e7f6a19554e33659be44546d44a2f7572ac7d2a/groovy-0.1.2-py3-none-any.whl", hash = "sha256:7f7975bab18c729a257a8b1ae9dcd70b7cafb1720481beae47719af57c35fa64", size = 14090, upload-time = "2025-02-28T20:24:55.152Z" },
-]
-
-[[package]]
-name = "browsecomp-plus"
-version = "0.1.0"
-source = { virtual = "." }
-dependencies = [
-    { name = "accelerate" },
-    { name = "anthropic" },
-    { name = "datasets" },
-    { name = "deepspeed" },
-    { name = "faiss-cpu" },
-    { name = "fastmcp" },
-    { name = "google-genai" },
-    { name = "openai" },
-    { name = "peft" },
-    { name = "pyngrok" },
-    { name = "pyserini" },
-    { name = "python-dotenv" },
-    { name = "qwen-agent", extra = ["gui", "mcp", "rag"] },
-    { name = "qwen-omni-utils" },
-    { name = "rich" },
-    { name = "tevatron" },
-    { name = "torchvision" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "vllm" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "accelerate", specifier = ">=1.9.0" },
-    { name = "anthropic", specifier = ">=0.58.2" },
-    { name = "datasets", specifier = ">=4.0.0" },
-    { name = "deepspeed", specifier = ">=0.17.2" },
-    { name = "faiss-cpu", specifier = ">=1.11.0.post1" },
-    { name = "fastmcp", specifier = "==2.9.2" },
-    { name = "google-genai", specifier = ">=1.27.0" },
-    { name = "openai", specifier = ">=1.97.0" },
-    { name = "peft", specifier = ">=0.16.0" },
-    { name = "pyngrok", specifier = ">=7.2.12" },
-    { name = "pyserini", specifier = ">=1.2.0" },
-    { name = "python-dotenv", specifier = ">=1.1.1" },
-    { name = "qwen-agent", extras = ["gui", "mcp", "rag"], specifier = "==0.0.27" },
-    { name = "qwen-omni-utils", specifier = "==0.0.8" },
-    { name = "rich", specifier = ">=14.0.0" },
-    { name = "tevatron", git = "https://github.com/texttron/tevatron.git?rev=main" },
-    { name = "torchvision" },
-    { name = "tqdm", specifier = ">=4.67.1" },
-    { name = "transformers", specifier = ">=4.53.2" },
-    { name = "vllm", specifier = ">=0.9.0" },
 ]
 
 [[package]]
@@ -3921,6 +3957,19 @@ wheels = [
 ]
 
 [[package]]
+name = "rich-rst"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0b/40/905f612e7bf105d7efefa923542e0c85b731cf29bcc1864331427dbc52b8/rich_rst-2.0.2.tar.gz", hash = "sha256:664a669801695c5a126151338f309ce3ea3e0ea081c89a4130b8a4f659911ed9", size = 300822, upload-time = "2026-06-25T17:24:14.298Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/5f/62fdf0f574ec75af7ada8ad27c1a67e3723d491143bc88d5371c25673949/rich_rst-2.0.2-py3-none-any.whl", hash = "sha256:7bc2923929c9bbc61aadfef2069b742446823b306af84cf9e0f56b965a3d3035", size = 273082, upload-time = "2026-06-25T17:24:09.557Z" },
+]
+
+[[package]]
 name = "rich-toolkit"
 version = "0.14.8"
 source = { registry = "https://pypi.org/simple" }
@@ -4700,6 +4749,34 @@ wheels = [
 ]
 
 [[package]]
+name = "together"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "cyclopts" },
+    { name = "detect-agent" },
+    { name = "distro" },
+    { name = "filelock" },
+    { name = "httpx" },
+    { name = "pillow" },
+    { name = "pydantic" },
+    { name = "rich" },
+    { name = "sniffio" },
+    { name = "tabulate" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
+    { name = "tqdm" },
+    { name = "types-pyyaml" },
+    { name = "types-tabulate" },
+    { name = "types-tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/b3/9515053204ca9f947b3d716edc068c9f4323c10574826a9f1a1c3736d4dc/together-2.19.0.tar.gz", hash = "sha256:cca656258425a401470cfcd7c93a88d3392b3f05d84c2a2b871f1ecb0f23ccc1", size = 616205, upload-time = "2026-06-24T21:32:58.282Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/c2/73ce0b47f9aff965a3e8e0a813620e6a216e2a93c2d6539ec8c4d87ba0be/together-2.19.0-py3-none-any.whl", hash = "sha256:381128b93ab5160134b78f3abc2fbe38a23fd55e4485367394c28f2ef297e068", size = 418832, upload-time = "2026-06-24T21:32:59.497Z" },
+]
+
+[[package]]
 name = "tokenizers"
 version = "0.21.2"
 source = { registry = "https://pypi.org/simple" }
@@ -4722,6 +4799,60 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a4/d2/faa1acac3f96a7427866e94ed4289949b2524f0c1878512516567d80563c/tokenizers-0.21.2-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:106746e8aa9014a12109e58d540ad5465b4c183768ea96c03cbc24c44d329958", size = 9470074, upload-time = "2025-06-24T10:24:50.378Z" },
     { url = "https://files.pythonhosted.org/packages/d8/a5/896e1ef0707212745ae9f37e84c7d50269411aef2e9ccd0de63623feecdf/tokenizers-0.21.2-cp39-abi3-win32.whl", hash = "sha256:cabda5a6d15d620b6dfe711e1af52205266d05b379ea85a8a301b3593c60e962", size = 2330115, upload-time = "2025-06-24T10:24:55.069Z" },
     { url = "https://files.pythonhosted.org/packages/13/c3/cc2755ee10be859c4338c962a35b9a663788c0c0b50c0bdd8078fb6870cf/tokenizers-0.21.2-cp39-abi3-win_amd64.whl", hash = "sha256:58747bb898acdb1007f37a7bbe614346e98dc28708ffb66a3fd50ce169ac6c98", size = 2509918, upload-time = "2025-06-24T10:24:53.71Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
 ]
 
 [[package]]
@@ -4909,6 +5040,48 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c5/8c/7d682431efca5fd290017663ea4588bf6f2c6aad085c7f108c5dbc316e70/typer-0.16.0.tar.gz", hash = "sha256:af377ffaee1dbe37ae9440cb4e8f11686ea5ce4e9bae01b84ae7c63b87f1dd3b", size = 102625, upload-time = "2025-05-26T14:30:31.824Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/42/3efaf858001d2c2913de7f354563e3a3a2f0decae3efe98427125a8f441e/typer-0.16.0-py3-none-any.whl", hash = "sha256:1f79bed11d4d02d4310e3c1b7ba594183bcedb0ac73b27a9e5f28f6fb5b98855", size = 46317, upload-time = "2025-05-26T14:30:30.523Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260518"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/83/4a1afc3fbfcf5b8d46fc390cd95ed6b0dc9010a265f4e9f46314efffa37a/types_pyyaml-6.0.12.20260518.tar.gz", hash = "sha256:d917f83fb38462550338c1297faedd860b3ec83912b96b1e3d73255f7473e466", size = 17850, upload-time = "2026-05-18T06:01:58.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/a2/c01db32be2ae7d6a1689972f3c492b149ee4e164b12fdfd9f64b50888215/types_pyyaml-6.0.12.20260518-py3-none-any.whl", hash = "sha256:d2150f75a231c9fe9c7463bd29487d93e60bac90400287351384bc2284eba7cd", size = 20312, upload-time = "2026-05-18T06:01:57.368Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
+]
+
+[[package]]
+name = "types-tabulate"
+version = "0.10.0.20260508"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/af/c100d86897d3fdb010d8f813569fa80355b5cb553f51080e37d4f3c451bb/types_tabulate-0.10.0.20260508.tar.gz", hash = "sha256:8e51f159e8b24976849706ae2ed1dc9adba8ebbd080b17e494ebb66a8cc92c74", size = 8395, upload-time = "2026-05-08T04:47:58.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/36/443b700f54a585cf8ed4e76d8ad08b12df6914f8782a2788ecd0d8491519/types_tabulate-0.10.0.20260508-py3-none-any.whl", hash = "sha256:b1e1a2d0456fbd655a71690b09a7aaeffdf2978d32049184ea436492aa51d20a", size = 8137, upload-time = "2026-05-08T04:47:57.872Z" },
+]
+
+[[package]]
+name = "types-tqdm"
+version = "4.68.0.20260608"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "types-requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/e0/3facccb1ff69970c73fca7a8028286c233d4c1312c475a65fb3d896f56d9/types_tqdm-4.68.0.20260608.tar.gz", hash = "sha256:e1dfddf8770fbc30ecaf95ae57c286397831235064308f7dfc2b1d6684a76107", size = 18470, upload-time = "2026-06-08T06:26:06.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/53/e8/61d95bfd49d1609fb8e8c5e06f4a094183411988a6f448873f5de6602499/types_tqdm-4.68.0.20260608-py3-none-any.whl", hash = "sha256:450a6e7e9e9b604928968927c414b32970e40091213c4180e1ed470905b13eff", size = 24858, upload-time = "2026-06-08T06:26:05.741Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add SETUP guide, Together AI judge and evaluation improvements

- Add comprehensive SETUP.md documenting single RTX 4090 workflow for
  Qwen3.5-9B benchmark runs, including vLLM serve config, BM25 server,
  agent runner, evaluation, and leaderboard submission steps
- Add Together AI inference to evaluate_run.py as an alternative
  to local vLLM judging (parallelized via --num-workers)
- Extend evaluate_run.py with citation metrics (precision/recall),
  retrieval recall tracking, calibration error, and detailed CSV export
- Update pyproject.toml and uv.lock for new dependencies
